### PR TITLE
Default configuration for php-cs-fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,23 @@
+<?php
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->exclude('vendor')
+    ->in(__DIR__);
+
+return Symfony\CS\Config\Config::create()
+    ->fixers(array(
+        // Use default symfony level but disable the following..
+        // Concatenation should be used with at least one whitespace around.
+        '-concat_without_spaces',
+        // An empty line feed should precede a return statement.
+        '-return',
+        // A return statement wishing to return nothing should be simply "return".
+        '-empty_return',
+        // Phpdocs short descriptions should end in either a full stop, exclamation mark, or question mark.
+        '-phpdoc_short_description',
+        // Pre incrementation/decrementation should be used if possible.
+        '-pre_increment',
+        // A single space should be between cast and variable.
+        '-spaces_cast',
+    ))
+    ->finder($finder);

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "league/climate": "^3.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.7.*"
+    "phpunit/phpunit": "4.7.*",
+    "fabpot/php-cs-fixer": "^1.9"
   }
 }


### PR DESCRIPTION
php-cs-fixer helps conform to PSR or other coding standards. I've added php-cs-fixer to composer.json as require-dev and a default config.

To fix coding standards in all PHP files:
`vendor/bin/php-cs-fixer fix`

Diff the whole directory to see what was changed (it automatically looks for installed diff tools like kdiff3, meld, codecompare and a lot more)
`git difftool -d`

To preview on the command line without touching any files:
`vendor/bin/php-cs-fixer fix --dry-run --diff`

We can run and commit it if we agree on the settings. I'm using the default fixers: Symfony which includes PSR2. However I've excluded some by personal preference :)

Here's a [list of available fixers](https://github.com/FriendsOfPHP/PHP-CS-Fixer#user-content-usage). Right now everything with PSR* and Symfony should be enabled.