### PR TITLE
New settings for limiting results, custom sort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ env:
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source --dev
+matrix:
+  allow_failures:
+    - php: 7.0

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ The following settings are supported by fast-forward:
     * Default: 1
 
 ### Using custom settings in commands
-You can also create your own settings which can be accessed in commands:
+You can also create your own settings which can be accessed in commands:  
 `ff set location tokio`
 
-Any known settings in commands will be parsed. Surround the setting key with `@`:
+Use the setting name surrounded by `@` in your commands:  
 `weather @location@`
 
-The command that will be executed:
+The identifiers are replaced with the current or default value of the setting:  
 `weather tokio`

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ Optional Arguments:
 		Show a list of all current settings. Save to file: ff set -l > file.txt
 ```
 e.g.
-`ff set ff.limit 20` Limit to 20 results
-`ff set -l > settings.txt` Dump settings
+
+`ff set ff.limit 20` Limit to 20 results  
+`ff set -l > settings.txt` Dump settings  
 `ff set < settings.txt` or `ff set -i settings.txt` Import settings
 
 ### Supported and default settings

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
         * [Linux](#linux)
         * [Mac](#mac)
     * [Usage](#usage)
+    * [Settings](#settings)
+        * [Supported and default settings](#supported-and-default-settings)
+        * [Using custom settings in commands](#using-custom-settings-in-commands)
 
 ## Setup
 
@@ -61,3 +64,45 @@ Searching for _htd*_
 If the only result is _htd_ it will be executed, otherwise all matches will be displayed first.
 
     ff htd
+
+## Settings
+
+```
+Usage: ff [-i file, --import file] [-l, --list] [set] [key] [value]
+
+Optional Arguments:
+	-i file, --import file
+		Import from the specified file
+	-l, --list
+		Show a list of all current settings. Save to file: ff set -l > file.txt
+```
+e.g.
+`ff set ff.limit 20` Limit to 20 results
+`ff set -l > settings.txt` Dump settings
+`ff set < settings.txt` or `ff set -i settings.txt` Import settings
+
+### Supported and default settings
+The following settings are supported by fast-forward:
+
+* **ff.limit**
+    * Limit amount of results (> 0 or 0 for no limit)
+    * Default: 0
+* **ff.sort**
+    * Sort order of results (shortcut, description, command, hit_count, ts_created, ts_modified)
+    * Default: hit_count
+* **ff.interactive**
+    * Ask for missing input interactively (0 never, 1 always)
+    * Default: 1
+* **ff.color**
+    * Enable color output on supported systems (0/1)
+    * Default: 1
+
+### Using custom settings in commands
+You can also create your own settings which can be accessed in commands:
+`ff set location tokio`
+
+Any known settings in commands will be parsed. Surround the setting key with `@`:
+`weather @location@`
+
+The command that will be executed:
+`weather tokio`

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
   "require": {
     "nochso/orm": "~1.3",
     "league/climate": "^3.1",
-    "natedrake/datehelper": "0.1.4"
+    "natedrake/datehelper": "0.1.4",
+    "respect/validation": "^0.9.3"
   },
   "require-dev": {
     "phpunit/phpunit": "4.7.*",

--- a/src/Client.php
+++ b/src/Client.php
@@ -147,6 +147,13 @@ class Client
     }
 
     /**
+     * @return Settings
+     */
+    public function getSettings() {
+        return $this->settings;
+    }
+
+    /**
      * Saves a setting as a key/value pair
      *
      * @param string $key Any string that does not contain spaces

--- a/src/Client.php
+++ b/src/Client.php
@@ -54,6 +54,8 @@ class Client
         $this->settings = new Settings($this);
 
         $this->cli = new CLImate();
+        $migration = new Migration($this);
+        $migration->run();
         if (OS::isType(OS::LINUX) && $this->get(Settings::COLOR)) {
             $this->cli->forceAnsiOn();
         }
@@ -62,8 +64,6 @@ class Client
         // Prevent the previous command from being executed in case anything fails later on
         $this->batchPath = $this->folder . DIRECTORY_SEPARATOR . 'cli-launch.temp.bat';
         file_put_contents($this->batchPath, '');
-        $migration = new Migration($this);
-        $migration->run();
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -48,19 +48,20 @@ class Client
      */
     public function init()
     {
-        $this->cli = new CLImate();
-        $this->cli->description('fast-forward ' . self::FF_VERSION);
-        if (OS::isType(OS::LINUX)) {
-            $this->cli->forceAnsiOn();
-        }
         $this->folder = dirname(dirname(__FILE__));
         chdir($this->folder);
+        DBA::connect('sqlite:' . $this->folder . '/db.sqlite', '', '');
+        $this->settings = new Settings($this);
+
+        $this->cli = new CLImate();
+        if (OS::isType(OS::LINUX) && $this->get('ff.color')) {
+            $this->cli->forceAnsiOn();
+        }
+        $this->cli->description('fast-forward ' . self::FF_VERSION);
 
         // Prevent the previous command from being executed in case anything fails later on
         $this->batchPath = $this->folder . DIRECTORY_SEPARATOR . 'cli-launch.temp.bat';
         file_put_contents($this->batchPath, '');
-        DBA::connect('sqlite:' . $this->folder . '/db.sqlite', '', '');
-        $this->settings = new Settings($this);
         $migration = new Migration($this);
         $migration->run();
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -54,7 +54,7 @@ class Client
         $this->settings = new Settings($this);
 
         $this->cli = new CLImate();
-        if (OS::isType(OS::LINUX) && $this->get('ff.color')) {
+        if (OS::isType(OS::LINUX) && $this->get(Settings::COLOR)) {
             $this->cli->forceAnsiOn();
         }
         $this->cli->description('fast-forward ' . self::FF_VERSION);

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,7 +9,6 @@ use phparsenal\fastforward\Command\Delete;
 use phparsenal\fastforward\Command\Run;
 use phparsenal\fastforward\Command\Set;
 use phparsenal\fastforward\Command\Update;
-use phparsenal\fastforward\Model\Setting;
 
 class Client
 {
@@ -40,6 +39,11 @@ class Client
     private $commands = array();
 
     /**
+     * @var Settings
+     */
+    private $settings;
+
+    /**
      * Get folder path and connect to the database
      */
     public function init()
@@ -56,6 +60,7 @@ class Client
         $this->batchPath = $this->folder . DIRECTORY_SEPARATOR . 'cli-launch.temp.bat';
         file_put_contents($this->batchPath, '');
         DBA::connect('sqlite:' . $this->folder . '/db.sqlite', '', '');
+        $this->settings = new Settings($this);
         $migration = new Migration($this);
         $migration->run();
     }
@@ -150,31 +155,7 @@ class Client
      */
     public function set($key, $value)
     {
-        if (strpos($key, ' ') !== false) {
-            throw new \Exception('Error while trying to save setting "' . $key . '": Key name must not contain spaces.');
-        }
-        $setting = $this->get($key, true);
-        if ($setting === null) {
-            $setting = new Setting();
-            $setting->key = $key;
-        }
-
-        if ($setting->value === null) {
-            $this->cli
-                ->out("Inserting new setting:")
-                ->out("$key = $value");
-        } elseif ($setting->value !== $value) {
-            $this->cli
-                ->out("Changing setting:")
-                ->out("$key = {$setting->value} --> <bold>$value</bold>");
-        } else {
-            $this->cli
-                ->out("Setting already up-to-date:")
-                ->out("$key = $value");
-        }
-
-        $setting->value = $value;
-        $setting->save();
+        $this->settings->set($key, $value);
     }
 
     /**
@@ -186,10 +167,6 @@ class Client
      */
     public function get($key, $returnModel = false)
     {
-        $setting = Setting::select()->eq('key', $key)->one();
-        if ($returnModel || $setting === null) {
-            return $setting;
-        }
-        return $setting->value;
+        return $this->settings->get($key, $returnModel);
     }
 }

--- a/src/Command/Add.php
+++ b/src/Command/Add.php
@@ -3,6 +3,7 @@
 namespace phparsenal\fastforward\Command;
 
 use phparsenal\fastforward\Model\Bookmark;
+use phparsenal\fastforward\Settings;
 
 class Add extends AbstractCommand implements CommandInterface
 {
@@ -30,7 +31,7 @@ class Add extends AbstractCommand implements CommandInterface
 
     private function addCommandInteractive()
     {
-        if (!$this->client->get('ff.interactive')) {
+        if (!$this->client->get(Settings::INTERACTIVE)) {
             return;
         }
         $this->cli->br()->whisper('Running command interactively..');

--- a/src/Command/Add.php
+++ b/src/Command/Add.php
@@ -30,6 +30,9 @@ class Add extends AbstractCommand implements CommandInterface
 
     private function addCommandInteractive()
     {
+        if (!$this->client->get('ff.interactive')) {
+            return;
+        }
         $this->cli->br()->whisper('Running command interactively..');
         $bookmark = new Bookmark();
         $args = $this->cli->arguments->all();

--- a/src/Command/Delete.php
+++ b/src/Command/Delete.php
@@ -5,6 +5,7 @@ namespace phparsenal\fastforward\Command;
 
 use nochso\ORM\Model;
 use phparsenal\fastforward\Model\Bookmark;
+use phparsenal\fastforward\Settings;
 
 class Delete extends AbstractCommand implements CommandInterface
 {
@@ -56,7 +57,7 @@ class Delete extends AbstractCommand implements CommandInterface
 
     public function deleteCommandInteractive()
     {
-        if (!$this->client->get('ff.interactive')) {
+        if (!$this->client->get(Settings::INTERACTIVE)) {
             return;
         }
         $this->cli->br()->whisper('Running command interactively..');

--- a/src/Command/Delete.php
+++ b/src/Command/Delete.php
@@ -56,6 +56,9 @@ class Delete extends AbstractCommand implements CommandInterface
 
     public function deleteCommandInteractive()
     {
+        if (!$this->client->get('ff.interactive')) {
+            return;
+        }
         $this->cli->br()->whisper('Running command interactively..');
         $args = $this->cli->arguments->all();
         $bookmark = new Bookmark();

--- a/src/Command/Run.php
+++ b/src/Command/Run.php
@@ -4,6 +4,7 @@ namespace phparsenal\fastforward\Command;
 
 use phparsenal\fastforward\Model\Bookmark;
 use NateDrake\DateHelper\DateFormat;
+use phparsenal\fastforward\Settings;
 
 class Run extends AbstractCommand implements CommandInterface
 {
@@ -110,7 +111,7 @@ class Run extends AbstractCommand implements CommandInterface
             $query->like('shortcut', $term . '%');
         }
 
-        $sortColumn = $this->client->get('ff.sort');
+        $sortColumn = $this->client->get(Settings::SORT);
         $columnMap = Bookmark::select()->toAssoc();
         if ($sortColumn === null || !isset($columnMap[$sortColumn])) {
             $sortColumn = 'hit_count';
@@ -123,7 +124,7 @@ class Run extends AbstractCommand implements CommandInterface
         }
 
         // Don't limit when setting not set or zero
-        $maxRows = $this->client->get('ff.maxrows');
+        $maxRows = $this->client->get(Settings::LIMIT);
         if ($maxRows !== null && $maxRows !== 0) {
             $query->limit($maxRows);
         }

--- a/src/Command/Run.php
+++ b/src/Command/Run.php
@@ -42,6 +42,10 @@ class Run extends AbstractCommand implements CommandInterface
             $query->like('shortcut', $term . '%');
         }
         $query->orderDesc('hit_count');
+        $maxRows = $this->client->get('ff.maxrows');
+        if ($maxRows !== null) {
+            $query->limit($maxRows);
+        }
         $bookmarks = $query->all();
         $bm = $this->selectBookmark($bookmarks, $searchTerms);
         if ($bm !== null) {

--- a/src/Command/Run.php
+++ b/src/Command/Run.php
@@ -113,7 +113,7 @@ class Run extends AbstractCommand implements CommandInterface
 
         $sortColumn = $this->client->get(Settings::SORT);
         $columnMap = Bookmark::select()->toAssoc();
-        if ($sortColumn === null || !isset($columnMap[$sortColumn])) {
+        if (!isset($columnMap[$sortColumn])) {
             $sortColumn = 'hit_count';
         }
         // Large hit counts and latest time stamps first

--- a/src/Command/Run.php
+++ b/src/Command/Run.php
@@ -37,16 +37,7 @@ class Run extends AbstractCommand implements CommandInterface
 
     private function runBookmark($searchTerms)
     {
-        $query = Bookmark::select();
-        foreach ($searchTerms as $term) {
-            $query->like('shortcut', $term . '%');
-        }
-        $query->orderDesc('hit_count');
-        $maxRows = $this->client->get('ff.maxrows');
-        if ($maxRows !== null) {
-            $query->limit($maxRows);
-        }
-        $bookmarks = $query->all();
+        $bookmarks = $this->searchBookmarks($searchTerms);
         $bm = $this->selectBookmark($bookmarks, $searchTerms);
         if ($bm !== null) {
             $bm->run($this->client);
@@ -106,5 +97,24 @@ class Run extends AbstractCommand implements CommandInterface
             }
         }
         return null;
+    }
+
+    /**
+     * @param array $searchTerms
+     * @return \nochso\ORM\ResultSet
+     */
+    private function searchBookmarks($searchTerms)
+    {
+        $query = Bookmark::select();
+        foreach ($searchTerms as $term) {
+            $query->like('shortcut', $term . '%');
+        }
+        $query->orderDesc('hit_count');
+        $maxRows = $this->client->get('ff.maxrows');
+        if ($maxRows !== null) {
+            $query->limit($maxRows);
+        }
+        $bookmarks = $query->all();
+        return $bookmarks;
     }
 }

--- a/src/Command/Set.php
+++ b/src/Command/Set.php
@@ -30,6 +30,13 @@ class Set extends AbstractCommand implements CommandInterface
             $this->client->set($key, $value);
             return;
         }
+
+        // Show info about setting when no value is supplied
+        if ($key !== null && $value === null) {
+            $this->client->getSettings()->showSupportedSettings($key);
+            return;
+        }
+
         if ($args->defined('list')) {
             $this->listAll();
             return;

--- a/src/Command/Set.php
+++ b/src/Command/Set.php
@@ -1,27 +1,14 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: amblin
- * Date: 05/07/15
- * Time: 15:21
- */
 
 namespace phparsenal\fastforward\Command;
-
 
 use phparsenal\fastforward\Model\Setting;
 
 /**
  * Save and list settings
- *
- * TODO Allow importing of many settings at once
- * TODO Use some kind of namespacing? e.g. ff.* for global, add.* for certain commands
- * TODO Allow the user to include these as variables in commands, e.g. $user.home will be replaced with its value
- * during run time
  */
 class Set extends AbstractCommand implements CommandInterface
 {
-
     protected $name = 'set';
 
     /**
@@ -57,12 +44,12 @@ class Set extends AbstractCommand implements CommandInterface
                 'list' => array(
                     'prefix' => 'l',
                     'longPrefix' => 'list',
-                    'description' => "Show a list of all current settings. Save to file: ff set -l > file.txt",
-                    'noValue' => true
+                    'description' => 'Show a list of all current settings. Save to file: ff set -l > file.txt',
+                    'noValue' => true,
                 ),
                 'set' => array(
                     'description' => 'Command to set a variable',
-                    'required' => true
+                    'required' => true,
                 ),
                 'key' => array(
                     'description' => 'Name or key of the setting',
@@ -74,7 +61,7 @@ class Set extends AbstractCommand implements CommandInterface
                     'prefix' => 'i',
                     'longPrefix' => 'import',
                     'description' => 'Import from the specified file',
-                )
+                ),
             )
         );
     }
@@ -90,6 +77,7 @@ class Set extends AbstractCommand implements CommandInterface
 
     /**
      * @param array $argv
+     *
      * @throws \Exception
      */
     private function import($argv)
@@ -122,6 +110,7 @@ class Set extends AbstractCommand implements CommandInterface
 
     /**
      * @param $args
+     *
      * @return array
      */
     private function getLinesFile($args)
@@ -133,6 +122,7 @@ class Set extends AbstractCommand implements CommandInterface
 
     /**
      * @param $lines
+     *
      * @throws \Exception
      */
     private function addLines($lines)

--- a/src/Command/Set.php
+++ b/src/Command/Set.php
@@ -21,7 +21,7 @@ class Set extends AbstractCommand implements CommandInterface
             $args = $this->cli->arguments;
             $args->parse();
         } catch (\Exception $e) {
-            $this->cli->arguments->usage($this->cli, $argv);
+            $this->showUsage($argv);
             return;
         }
         $key = $args->get('key');
@@ -87,10 +87,16 @@ class Set extends AbstractCommand implements CommandInterface
         if ($args->defined('file')) {
             $lines = $this->getLinesFile($args);
         } else {
-            $this->cli->arguments->usage($this->cli, $argv);
+            $this->showUsage($argv);
             $lines = $this->getLinesStdin();
         }
         $this->addLines($lines);
+    }
+
+    private function showUsage($argv)
+    {
+        $this->cli->arguments->usage($this->cli, $argv);
+        $this->client->getSettings()->showSupportedSettings();
     }
 
     /**

--- a/src/Command/Update.php
+++ b/src/Command/Update.php
@@ -27,6 +27,9 @@ class Update extends AbstractCommand implements CommandInterface
 
     public function updateCommandInteractive()
     {
+        if (!$this->client->get('ff.interactive')) {
+            return;
+        }
         $this->cli->br()->whisper('Running command interactively..');
         $bookmark = new Bookmark();
         $tableArgMap = array();

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -85,7 +85,7 @@ class Migration
         // There's already a bookmark table, but no settings yet.
         // Basically the state of the project as this was written.
         $sql = '
-                CREATE TABLE "setting" (
+                CREATE TABLE IF NOT EXISTS "setting" (
                   "key" text NOT NULL,
                   "value" text NOT NULL
                 )';

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -152,7 +152,7 @@ class Migration
     public function getDatabaseVersion()
     {
         try {
-            return $this->client->get('database.version');
+            return $this->client->get(Settings::DATABASE_VERSION);
         } catch (\PDOException $e) {
             return null;
         }
@@ -160,7 +160,7 @@ class Migration
 
     private function saveDatabaseVersion()
     {
-        $this->client->set('database.version', Client::FF_VERSION);
+        $this->client->set(Settings::DATABASE_VERSION, Client::FF_VERSION);
     }
 
     /**

--- a/src/Model/Bookmark.php
+++ b/src/Model/Bookmark.php
@@ -4,6 +4,7 @@ namespace phparsenal\fastforward\Model;
 use nochso\ORM\Model;
 use phparsenal\fastforward\Client;
 use phparsenal\fastforward\OS;
+use phparsenal\fastforward\Settings;
 
 class Bookmark extends Model
 {
@@ -77,14 +78,15 @@ class Bookmark extends Model
     public function run($client)
     {
         $client->getCLI()->info("Running '" . $this->shortcut . "' for the " . $client->ordinal($this->hit_count) . " time.");
+        $command = $client->getSettings()->parseIdentifiers($this->command);
         switch (OS::getType()) {
             case OS::LINUX:
                 // Disable Ansi to keep the output clean
                 $client->getCLI()->forceAnsiOff();
-                $client->getCLI()->br()->out("cmd:" . $this->command)->br();
+                $client->getCLI()->br()->out("cmd:" . $command)->br();
                 break;
             case OS::WINDOWS:
-                file_put_contents($client->getBatchPath(), $this->command);
+                file_put_contents($client->getBatchPath(), $command);
                 break;
         }
         $this->hit_count++;

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -11,13 +11,13 @@ class Settings
     /** @var Client */
     private $client;
 
-    private $knownSettings = array();
+    private $supportedSettings = array();
 
     public function __construct(Client $client)
     {
         $this->client = $client;
-        $this->knownSettings['ff.maxrows'] = array(
-            'desc' => 'Limit amount of results',
+        $this->supportedSettings['ff.maxrows'] = array(
+            'desc' => 'Limit amount of results (> 0 or 0 for no limit)',
             'validation' => array(v::int()->min(0, true)),
         );
     }
@@ -85,10 +85,10 @@ class Settings
      */
     public function validate(Setting $setting)
     {
-        if (!isset($this->knownSettings[$setting->key])) {
+        if (!isset($this->supportedSettings[$setting->key])) {
             return true;
         }
-        $info = $this->knownSettings[$setting->key];
+        $info = $this->supportedSettings[$setting->key];
         if (!isset($info['validation'])) {
             return true;
         }
@@ -102,5 +102,17 @@ class Settings
             }
         }
         return true;
+    }
+
+    public function showSupportedSettings()
+    {
+        $cli = $this->client->getCLI();
+        $cli->br();
+        $cli->info('Supported settings:');
+        foreach ($this->supportedSettings as $key => $info) {
+            $cli->out($key);
+            $cli->tab()->out($info['desc']);
+        }
+        $cli->br();
     }
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -28,6 +28,11 @@ class Settings
             'validation' => array(v::in($sortColumns)),
             'default' => 'hit_count'
         );
+        $this->supportedSettings['ff.interactive'] = array(
+            'desc' => 'Ask for missing input interactively (0 never, 1 always)',
+            'validation' => array(v::in(array('0', '1'))),
+            'default' => '1'
+        );
     }
 
     /**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -17,26 +17,28 @@ class Settings
     public function __construct(Client $client)
     {
         $this->client = $client;
-        $this->supportedSettings['ff.maxrows'] = array(
-            'desc' => 'Limit amount of results (> 0 or 0 for no limit)',
-            'validation' => array(v::int()->min(0, true)),
-            'default' => 0,
-        );
         $sortColumns = array_keys(Bookmark::select()->toAssoc());
-        $this->supportedSettings['ff.sort'] = array(
-            'desc' => 'Sort order of results (' . implode($sortColumns, ', ') . ')',
-            'validation' => array(v::in($sortColumns)),
-            'default' => 'hit_count'
-        );
-        $this->supportedSettings['ff.interactive'] = array(
-            'desc' => 'Ask for missing input interactively (0 never, 1 always)',
-            'validation' => array(v::in(array('0', '1'))),
-            'default' => '1'
-        );
-        $this->supportedSettings['ff.color'] = array(
-            'desc' => 'Enable color output on supported systems (0/1)',
-            'validation' => array(v::in(array('0', '1'))),
-            'default' => 1
+        $this->supportedSettings = array(
+            'ff.maxrows' => array(
+                'desc' => 'Limit amount of results (> 0 or 0 for no limit)',
+                'validation' => array(v::int()->min(0, true)),
+                'default' => 0,
+            ),
+            'ff.sort' => array(
+                'desc' => 'Sort order of results (' . implode($sortColumns, ', ') . ')',
+                'validation' => array(v::in($sortColumns)),
+                'default' => 'hit_count',
+            ),
+            'ff.interactive' => array(
+                'desc' => 'Ask for missing input interactively (0 never, 1 always)',
+                'validation' => array(v::in(array('0', '1'))),
+                'default' => '1',
+            ),
+            'ff.color' => array(
+                'desc' => 'Enable color output on supported systems (0/1)',
+                'validation' => array(v::in(array('0', '1'))),
+                'default' => 1,
+            ),
         );
     }
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -185,4 +185,33 @@ class Settings
         }
         $cli->br();
     }
+
+    /**
+     * Replace setting identifiers with their values.
+     *
+     * Surround the key/name of a setting with an @ to replace it with its
+     * current or default value.
+     *
+     * e.g. "weather @location@" turns into "weather tokio"
+     *
+     * @param string $template
+     *
+     * @return string
+     */
+    public function parseIdentifiers($template)
+    {
+        $out = $template;
+        $token = '@';
+        $pattern = "/$token([a-zA-Z0-9.]+)$token/";
+        if (preg_match_all($pattern, $template, $matches)) {
+            $candidateKeys = $matches[1];
+            foreach ($candidateKeys as $key) {
+                $value = $this->get($key);
+                if ($value !== null) {
+                    $out = str_replace($token . $key . $token, $value, $out);
+                }
+            }
+        }
+        return $out;
+    }
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -33,6 +33,11 @@ class Settings
             'validation' => array(v::in(array('0', '1'))),
             'default' => '1'
         );
+        $this->supportedSettings['ff.color'] = array(
+            'desc' => 'Enable color output on supported systems (0/1)',
+            'validation' => array(v::in(array('0', '1'))),
+            'default' => 1
+        );
     }
 
     /**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -109,9 +109,15 @@ class Settings
         $cli = $this->client->getCLI();
         $cli->br();
         $cli->info('Supported settings:');
+        $currentSettings = Setting::select()
+            ->in('key', array_keys($this->supportedSettings))
+            ->all();
         foreach ($this->supportedSettings as $key => $info) {
-            $cli->out($key);
-            $cli->tab()->out($info['desc']);
+            $cli->inline($key);
+            if (isset($currentSettings[$key])) {
+                $cli->inline(' = <bold>' . $currentSettings[$key]->value . '</bold>');
+            }
+            $cli->br()->tab()->out($info['desc']);
         }
         $cli->br();
     }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -110,15 +110,30 @@ class Settings
         return true;
     }
 
-    public function showSupportedSettings()
+    /**
+     * Shows support info for all or specified setting(s)
+     *
+     * @param null|string $key Key/name of a specific setting. Leave empty for
+     *                         all settings.
+     */
+    public function showSupportedSettings($key = null)
     {
+        $settings = array();
+        if ($key !== null && isset($this->supportedSettings[$key])) {
+            $settings[$key] = $this->supportedSettings[$key];
+        } else {
+            $settings = $this->supportedSettings;
+        }
+
+        $currentSettings = Setting::select()
+            ->in('key', array_keys($settings))
+            ->all();
+
         $cli = $this->client->getCLI();
         $cli->br();
         $cli->info('Supported settings:');
-        $currentSettings = Setting::select()
-            ->in('key', array_keys($this->supportedSettings))
-            ->all();
-        foreach ($this->supportedSettings as $key => $info) {
+
+        foreach ($settings as $key => $info) {
             $cli->inline($key);
             if (isset($currentSettings[$key])) {
                 $cli->inline(' = <bold>' . $currentSettings[$key]->value . '</bold>');

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -21,22 +21,22 @@ class Settings
         $this->supportedSettings = array(
             'ff.maxrows' => array(
                 'desc' => 'Limit amount of results (> 0 or 0 for no limit)',
-                'validation' => array(v::int()->min(0, true)),
+                'validation' => array(v::int()->notEmpty()->min(0, true)),
                 'default' => 0,
             ),
             'ff.sort' => array(
                 'desc' => 'Sort order of results (' . implode($sortColumns, ', ') . ')',
-                'validation' => array(v::in($sortColumns)),
+                'validation' => array(v::in($sortColumns)->notEmpty()),
                 'default' => 'hit_count',
             ),
             'ff.interactive' => array(
                 'desc' => 'Ask for missing input interactively (0 never, 1 always)',
-                'validation' => array(v::in(array('0', '1'))),
+                'validation' => array(v::in(array('0', '1'))->notEmpty()),
                 'default' => '1',
             ),
             'ff.color' => array(
                 'desc' => 'Enable color output on supported systems (0/1)',
-                'validation' => array(v::in(array('0', '1'))),
+                'validation' => array(v::in(array('0', '1'))->notEmpty()),
                 'default' => 1,
             ),
         );

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -2,6 +2,7 @@
 
 namespace phparsenal\fastforward;
 
+use phparsenal\fastforward\Model\Bookmark;
 use phparsenal\fastforward\Model\Setting;
 use Respect\Validation\Exceptions\NestedValidationExceptionInterface;
 use Respect\Validation\Validator as v;
@@ -19,6 +20,11 @@ class Settings
         $this->supportedSettings['ff.maxrows'] = array(
             'desc' => 'Limit amount of results (> 0 or 0 for no limit)',
             'validation' => array(v::int()->min(0, true)),
+        );
+        $sortColumns = array_keys(Bookmark::select()->toAssoc());
+        $this->supportedSettings['ff.sort'] = array(
+            'desc' => 'Sort order of results (' . implode($sortColumns, ', ') . ')',
+            'validation' => array(v::in($sortColumns)),
         );
     }
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -97,7 +97,6 @@ class Settings
                 $setting = new Setting();
                 $setting->key = $key;
                 $setting->value = $this->supportedSettings[$key]['default'];
-                $setting->save();
             }
         }
         if ($returnModel || $setting === null) {

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace phparsenal\fastforward;
+
+use phparsenal\fastforward\Model\Setting;
+
+class Settings
+{
+    /** @var Client */
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Saves a setting as a key/value pair
+     *
+     * @param string $key   Any string that does not contain spaces
+     * @param string $value
+     *
+     * @throws \Exception
+     */
+    public function set($key, $value)
+    {
+        if (strpos($key, ' ') !== false) {
+            throw new \Exception('Error while trying to save setting "' . $key . '": Key name must not contain spaces.');
+        }
+        $setting = $this->get($key, true);
+        if ($setting === null) {
+            $setting = new Setting();
+            $setting->key = $key;
+        }
+        $cli = $this->client->getCLI();
+        if ($setting->value === null) {
+            $cli->out('Inserting new setting:')
+                ->out("$key = $value");
+        } elseif ($setting->value !== $value) {
+            $cli->out('Changing setting:')
+                ->out("$key = {$setting->value} --> <bold>$value</bold>");
+        } else {
+            $cli->out('Setting already up-to-date:')
+                ->out("$key = $value");
+        }
+
+        $setting->value = $value;
+        $setting->save();
+    }
+
+    /**
+     * Return the string or Model value for $key
+     *
+     * @param string $key
+     * @param bool   $returnModel Returns a model instance when true
+     *
+     * @return null|string|Setting
+     */
+    public function get($key, $returnModel = false)
+    {
+        $setting = Setting::select()
+            ->eq('key', $key)
+            ->one();
+        if ($returnModel || $setting === null) {
+            return $setting;
+        }
+        return $setting->value;
+    }
+}


### PR DESCRIPTION
* Add setting `ff.maxrows` for limiting amount of results
* Add setting `ff.sort` for changing the sort column
* Add setting `ff.interactive` to control interactive prompts
* Display info about all settings: `ff set` or a specific setting `ff set <key>`
* Validate supported settings using [respect/validation](https://github.com/Respect/Validation)
* Support for default values
* Place-holders in commands: Replace `@key@` with value of setting `key`

Closes #9 